### PR TITLE
Access-Control-Allow headers

### DIFF
--- a/lib/PocketIO/Transport/BasePolling.pm
+++ b/lib/PocketIO/Transport/BasePolling.pm
@@ -95,7 +95,9 @@ sub _write {
         join(
             "\x0d\x0a" => 'HTTP/1.1 200 OK',
             'Content-Type: ' . $self->_content_type,
-            'Content-Length: ' . length($message), '', $message
+            'Content-Length: ' . length($message), '', $message,
+            'Access-Control-Allow-Origin: *',
+            'Access-Control-Allow-Credentials: *',
         ),
         sub {
             $handle->close;

--- a/lib/PocketIO/Transport/Htmlfile.pm
+++ b/lib/PocketIO/Transport/Htmlfile.pm
@@ -46,6 +46,8 @@ sub _dispatch_stream {
             'Content-Type: text/html',
             'Connection: keep-alive',
             'Transfer-Encoding: chunked',
+            'Access-Control-Allow-Origin: *',
+            'Access-Control-Allow-Credentials: *',
             '',
             sprintf('%x', 173 + 83),
             '<html><body><script>var _ = function (msg) { parent.s._(msg, document); };</script>'.

--- a/lib/PocketIO/Transport/XHRMultipart.pm
+++ b/lib/PocketIO/Transport/XHRMultipart.pm
@@ -72,6 +72,8 @@ sub _dispatch_stream {
         $handle->write(
             join "\x0d\x0a" => 'HTTP/1.1 200 OK',
             qq{Content-Type: multipart/x-mixed-replace;boundary="$boundary"},
+            'Access-Control-Allow-Origin: *',
+            'Access-Control-Allow-Credentials: *',
             'Connection: keep-alive', '', ''
         );
 


### PR DESCRIPTION
Added Access-Control-Allow-Origin: \* and Access-Control-Allow-Credentials: \* to support cross domain xhr in handshakes. The next Socket.io-client will need this when it checks if it can do cross domain xhrs, said @3rd-Eden.
